### PR TITLE
add WithFPGADevKitDesign config

### DIFF
--- a/craft/u500/src/DevKitFPGADesign.scala
+++ b/craft/u500/src/DevKitFPGADesign.scala
@@ -158,3 +158,7 @@ class DevKitU500FPGADesign extends Config(
   new U500DevKitConfig().alter((site, here, up) => {
     case DesignKey => { (p:Parameters) => new DevKitWrapper()(p) }
   }))
+
+class WithFPGADevKitDesign extends Config((site, here, up) => {
+  case DesignKey => { (p:Parameters) => new DevKitWrapper()(p) }
+})

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,10 +1,5 @@
 [
     {
-        "commit": "5bb8e804afa8d4d0379e06bccd3eb964972446a4",
-        "name": "soc-iofpga-sifive",
-        "source": "git@github.com:sifive/soc-iofpga-sifive.git"
-    },
-    {
         "commit": "40dbdf2327088b1f42974e1dc5cfe646bebdb08f",
         "name": "api-generator-sifive",
         "source": "git@github.com:sifive/api-generator-sifive.git"


### PR DESCRIPTION
This enables using the `DevKitFPGADesign` with other configs from the command line. Also gets rid of an unused wit dependency.